### PR TITLE
Flatten the matrix indices (line 95 and line 96) in tm_output_comp.py

### DIFF
--- a/ozone/components/tm_output_comp.py
+++ b/ozone/components/tm_output_comp.py
@@ -92,8 +92,8 @@ class TMOutputComp(ExplicitComponent):
                 y_name = get_name('y', state_name, i_step=i_step)
 
                 data = np.ones(size)
-                rows = state_arange[i_step + num_starting_times - 1, :]
-                cols = y_arange[0, :]
+                rows = (state_arange[i_step + num_starting_times - 1, :]).flatten()
+                cols = (y_arange[0, :]).flatten()
 
                 self.declare_partials(out_state_name, y_name, val=data, rows=rows, cols=cols)
 


### PR DESCRIPTION
The row and column indices in line 95 and line 96 of tm_output_comp.py are flattened so that this works for the states that have to be expressed in 3D (num_nodes,n,k) tensors.