### PR TITLE
Fix matrix sizing issues

### DIFF
--- a/ozone/components/dynamic_parameter_comp.py
+++ b/ozone/components/dynamic_parameter_comp.py
@@ -58,8 +58,16 @@ class DynamicParameterComp(ExplicitComponent):
             self.declare_partials(out_name, in_name, val=data, rows=rows, cols=cols)
 
     def compute(self, inputs, outputs):
+        normalized_times = self.options['normalized_times']
+        stage_norm_times = self.options['stage_norm_times']
+
+        num_times = len(normalized_times)
+        num_stage_times = len(stage_norm_times)
+
         for parameter_name, parameter in iteritems(self.options['dynamic_parameters']):
+            size = np.prod(parameter['shape'])
+            shape = parameter['shape']
             in_name = get_name('in', parameter_name)
             out_name = get_name('out', parameter_name)
 
-            outputs[out_name] = self.mtx.dot(inputs[in_name])
+            outputs[out_name] = self.mtx.dot(inputs[in_name].reshape((num_times, size))).reshape((num_stage_times,) + shape)

--- a/ozone/integrators/explicit_tm_integrator.py
+++ b/ozone/integrators/explicit_tm_integrator.py
@@ -100,7 +100,7 @@ class ExplicitTMIntegrator(Integrator):
 
                         arange = np.arange(((len(my_norm_times) - 1) * num_stages * size)).reshape(
                             ((len(my_norm_times) - 1, num_stages,) + shape))
-                        src_indices = arange[i_step, i_stage, :]
+                        src_indices = arange[i_step, i_stage, :].reshape((1,) + shape)
                         src_indices_list.append(src_indices)
                     self._connect_multiple(
                         self._get_dynamic_parameter_names('dynamic_parameter_comp', 'out'),


### PR DESCRIPTION
Fix matrix sizing issues in dynamic_parameter_comp.py (line 73) and explicit_tm_integrator.py (line 103).
**explicit_tm_integrator.py (line 103):** adding one dimension (from (k,x,y) to (1,k,x,y)) to make the out_name compatible with the dimension in OpenMDAO.

**explicit_tm_integrator.py (line 103):** changing the formulation to get the output matrix of dimension [s(number of stages), k(number of trajectory points), x, y].
